### PR TITLE
Fix for boundary in quotes

### DIFF
--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -96,7 +96,7 @@ export function getBoundary(header: string): string {
       const item = new String(items[i]).trim()
       if (item.indexOf('boundary') >= 0) {
         const k = item.split('=')
-        return new String(k[1]).trim()
+        return new String(k[1]).trim().replace(/^["']|["']$/g, "")
       }
     }
   }

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -42,6 +42,22 @@ describe('Multipart', function() {
     expect(boundary).to.be.equal('----WebKitFormBoundaryvm5A9tzU1ONaGP5B')
   })
 
+  it('should get boundary in single quotes', function() {
+    const header =
+      'multipart/form-data; boundary="----WebKitFormBoundaryvm5A9tzU1ONaGP5B"'
+    const boundary = getBoundary(header)
+
+    expect(boundary).to.be.equal('----WebKitFormBoundaryvm5A9tzU1ONaGP5B')
+  })
+  
+  it('should get boundary in double quotes', function() {
+    const header =
+      "multipart/form-data; boundary='----WebKitFormBoundaryvm5A9tzU1ONaGP5B'"
+    const boundary = getBoundary(header)
+
+    expect(boundary).to.be.equal('----WebKitFormBoundaryvm5A9tzU1ONaGP5B')
+  })
+  
   it('should not parse multipart if boundary is not correct', function() {
     const { body, boundary } = DemoData()
     const parts = parse(body, boundary + 'bad')


### PR DESCRIPTION
Some libraries could generate multipart request with boundary in quotes in Content-Type header