### PR TITLE
Fix sourcemaps by including /src in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 tsconfig.json
 tslint.json
 .nyc_output


### PR DESCRIPTION
This fixes #10.

Without this, any tool that tries to use the source maps published in this package will error, because they reference a file that isn't available.

There's no downside to this (AFAIK) other than a tiny increase in download size from npm.